### PR TITLE
fix: remove dotenv and tsc-alias dependencies for Smithery deployment

### DIFF
--- a/dist/smithery-entry.js
+++ b/dist/smithery-entry.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
-import { config } from "dotenv";
 import { randomUUID } from "node:crypto";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import createClearThoughtServer from "./index.js";
-config();
 // Export for Smithery - returns the MCP server instance
 export default function () {
     // Create MCP server using the proper factory function

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
         "LICENSE"
     ],
     "scripts": {
-        "build": "tsc && tsc-alias && chmod +x dist/index.js",
+        "build": "tsc && chmod +x dist/index.js",
         "build:smithery": "npx @smithery/cli build",
         "test": "vitest",
         "test:coverage": "vitest --coverage",

--- a/src/smithery-entry.ts
+++ b/src/smithery-entry.ts
@@ -1,10 +1,7 @@
 #!/usr/bin/env node
-import { config } from "dotenv";
 import { randomUUID } from "node:crypto";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import createClearThoughtServer from "./index.js";
-
-config();
 
 // Export for Smithery - returns the MCP server instance
 export default function () {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,10 +12,7 @@
     "resolveJsonModule": true,
     "declaration": false,
     "sourceMap": false,
-    "allowSyntheticDefaultImports": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    }
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "coverage", "**/*.test.ts", "tests/**/*"]


### PR DESCRIPTION
- Removed unnecessary dotenv import from smithery-entry.ts
- Removed tsc-alias from build process (not needed, no path aliases used)
- Removed unused path alias configuration from tsconfig.json
- Fixes Smithery Docker build failures

🤖 Generated with [Claude Code](https://claude.ai/code)