### PR TITLE
fix: exit stdio server when the client disconnects

### DIFF
--- a/cli/stdio-server.ts
+++ b/cli/stdio-server.ts
@@ -3,6 +3,18 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { defaultConfig } from "../src/config.js";
 import createClearThoughtServer from "../src/index.js";
 
+// Single idempotent shutdown path. Multiple lifecycle events can fire for one
+// disconnect (stdin end/close, transport/server close, SIGINT, SIGTERM); the
+// guard ensures only the first one shuts the process down.
+let shuttingDown = false;
+function shutdown(exitCode = 0): void {
+	if (shuttingDown) {
+		return;
+	}
+	shuttingDown = true;
+	process.exit(exitCode);
+}
+
 async function main() {
 	try {
 		// Parse environment variables for diagnostic configuration
@@ -29,6 +41,17 @@ async function main() {
 			config,
 		});
 
+		// MCP stdio lifecycle: when a client disconnects it closes stdin, so this
+		// process sees EOF on its input even though no signal is ever delivered.
+		// Exit on stdin end/close so we never linger as an orphaned process.
+		process.stdin.on("end", () => shutdown(0));
+		process.stdin.on("close", () => shutdown(0));
+
+		// Verified against @modelcontextprotocol/sdk@1.17.x: Protocol.connect()
+		// wraps the transport's onclose callback, and Protocol._onclose() invokes
+		// this server-level callback whenever the transport connection closes.
+		server.onclose = () => shutdown(0);
+
 		// Create stdio transport
 		const transport = new StdioServerTransport();
 
@@ -44,15 +67,15 @@ async function main() {
 	}
 }
 
-// Handle graceful shutdown
+// Handle graceful shutdown (routed through the shared idempotent guard)
 process.on("SIGINT", () => {
 	console.error("\nShutting down Clear Thought stdio server...");
-	process.exit(0);
+	shutdown(0);
 });
 
 process.on("SIGTERM", () => {
 	console.error("Received SIGTERM, shutting down...");
-	process.exit(0);
+	shutdown(0);
 });
 
 // Start the server

--- a/dist/cli/stdio-server.js
+++ b/dist/cli/stdio-server.js
@@ -2,6 +2,17 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { defaultConfig } from "../src/config.js";
 import createClearThoughtServer from "../src/index.js";
+// Single idempotent shutdown path. Multiple lifecycle events can fire for one
+// disconnect (stdin end/close, transport/server close, SIGINT, SIGTERM); the
+// guard ensures only the first one shuts the process down.
+let shuttingDown = false;
+function shutdown(exitCode = 0) {
+    if (shuttingDown) {
+        return;
+    }
+    shuttingDown = true;
+    process.exit(exitCode);
+}
 async function main() {
     try {
         // Parse environment variables for diagnostic configuration
@@ -24,6 +35,15 @@ async function main() {
             sessionId: `stdio-session-${Date.now()}`,
             config,
         });
+        // MCP stdio lifecycle: when a client disconnects it closes stdin, so this
+        // process sees EOF on its input even though no signal is ever delivered.
+        // Exit on stdin end/close so we never linger as an orphaned process.
+        process.stdin.on("end", () => shutdown(0));
+        process.stdin.on("close", () => shutdown(0));
+        // Verified against @modelcontextprotocol/sdk@1.17.x: Protocol.connect()
+        // wraps the transport's onclose callback, and Protocol._onclose() invokes
+        // this server-level callback whenever the transport connection closes.
+        server.onclose = () => shutdown(0);
         // Create stdio transport
         const transport = new StdioServerTransport();
         // Connect server to transport
@@ -37,14 +57,14 @@ async function main() {
         process.exit(1);
     }
 }
-// Handle graceful shutdown
+// Handle graceful shutdown (routed through the shared idempotent guard)
 process.on("SIGINT", () => {
     console.error("\nShutting down Clear Thought stdio server...");
-    process.exit(0);
+    shutdown(0);
 });
 process.on("SIGTERM", () => {
     console.error("Received SIGTERM, shutting down...");
-    process.exit(0);
+    shutdown(0);
 });
 // Start the server
 main().catch((error) => {

--- a/dist/src/config.js
+++ b/dist/src/config.js
@@ -57,6 +57,19 @@ export const ServerConfigSchema = z.object({
         .string()
         .default("")
         .describe("Env var name that contains the API key for the research provider"),
+    // Telemetry / Observability (Shinzo)
+    telemetryProvider: z
+        .enum(["none", "shinzo", "console"]) // console = local dev exporter
+        .default("none")
+        .describe("Telemetry provider to use"),
+    telemetryTokenEnv: z
+        .string()
+        .default("SHINZO_TOKEN")
+        .describe("Env var name that contains the Shinzo ingest token"),
+    telemetryEndpointEnv: z
+        .string()
+        .default("SHINZO_ENDPOINT")
+        .describe("Env var name that contains the Shinzo HTTP ingest endpoint (e.g., https://api.app.shinzo.ai/telemetry/ingest_http)"),
     // Code execution
     allowCodeExecution: z
         .boolean()
@@ -85,6 +98,9 @@ export const defaultConfig = {
     knowledgeGraphFile: "knowledge-graph.json",
     researchProvider: "none",
     researchApiKeyEnv: "",
+    telemetryProvider: "none",
+    telemetryTokenEnv: "SHINZO_TOKEN",
+    telemetryEndpointEnv: "SHINZO_ENDPOINT",
     allowCodeExecution: false,
     pythonCommand: "python3",
     executionTimeoutMs: 10000,

--- a/dist/src/index.js
+++ b/dist/src/index.js
@@ -6,6 +6,7 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import { SessionState } from "./state/SessionState.js";
 import { ClearThoughtParamsSchema, handleClearThoughtTool, } from "./tools/index.js";
 import { parseSrcbook, srcbookToResource, } from "./utils/srcbookParser.js";
+import { instrumentServer } from "@shinzolabs/instrumentation-mcp";
 /**
  * Creates a Clear Thought MCP server instance for a specific session
  * @param sessionId - Unique identifier for this session
@@ -23,6 +24,37 @@ export default function createClearThoughtServer({ sessionId, config, }) {
             resources: { listChanged: true },
         },
     });
+    // Wire telemetry (Shinzo) per configuration/env
+    try {
+        if (config.telemetryProvider === "shinzo") {
+            const endpoint = process.env[config.telemetryEndpointEnv] ||
+                process.env.SHINZO_ENDPOINT ||
+                "https://api.app.shinzo.ai/telemetry/ingest_http";
+            const token = process.env[config.telemetryTokenEnv] || process.env.SHINZO_TOKEN;
+            if (token) {
+                instrumentServer(server, {
+                    serverName: "clear-thought",
+                    serverVersion: "0.2.1",
+                    exporterEndpoint: endpoint,
+                    exporterAuth: { type: "bearer", token },
+                });
+            }
+            else if (config.debug) {
+                console.warn("Shinzo telemetry enabled but token not found in env; skipping instrumentation");
+            }
+        }
+        else if (config.telemetryProvider === "console") {
+            instrumentServer(server, {
+                serverName: "clear-thought",
+                serverVersion: "0.2.1",
+                exporterType: "console",
+                enableMetrics: false,
+            });
+        }
+    }
+    catch (e) {
+        console.warn("Telemetry initialization failed:", e);
+    }
     // Initialize session state
     const sessionState = new SessionState(sessionId, config);
     // Register request handlers for tools/list and tools/call

--- a/tests/stdio-lifecycle.test.ts
+++ b/tests/stdio-lifecycle.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Stdio process-lifecycle regression tests.
+ *
+ * Regression case: when the MCP client disconnects it closes the server
+ * process's stdin. No signal is delivered, so the server must exit on its own.
+ * Previously the server lingered forever (reparented to init) because the MCP
+ * SDK's StdioServerTransport (1.17.x) does not listen for stdin end/close and
+ * module-level notebook cleanup intervals keep the event loop alive.
+ *
+ * These tests spawn the REAL built entrypoint (dist/cli/stdio-server.js), so a
+ * build (`npm run build:stdio`) must exist before running them.
+ */
+
+import { type ChildProcess, execFile, spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it } from "vitest";
+
+const execFileAsync = promisify(execFile);
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const SERVER_PATH = path.resolve(here, "..", "dist", "cli", "stdio-server.js");
+const READY_MARKER = "Ready to receive commands...";
+
+/** Bounded waits; on expiry the child is force-killed so nothing leaks. */
+const START_TIMEOUT_MS = 15_000;
+const EXIT_TIMEOUT_MS = 5_000;
+const TEST_TIMEOUT_MS = START_TIMEOUT_MS + 2 * EXIT_TIMEOUT_MS + 10_000;
+
+interface SpawnedServer {
+	child: ChildProcess;
+	waitForReady: () => Promise<void>;
+	waitForExit: () => Promise<number | null>;
+}
+
+function spawnServer(): SpawnedServer {
+	expect(
+		fs.existsSync(SERVER_PATH),
+		`missing build output: ${SERVER_PATH}`,
+	).toBe(true);
+
+	const child = spawn(process.execPath, [SERVER_PATH], {
+		stdio: ["pipe", "ignore", "pipe"],
+	});
+
+	const exited = new Promise<number | null>((resolve) => {
+		child.once("exit", (code) => resolve(code));
+	});
+
+	function waitForReady(): Promise<void> {
+		return new Promise((resolve, reject) => {
+			let stderr = "";
+			const timer = setTimeout(() => {
+				cleanup();
+				child.kill("SIGKILL");
+				reject(
+					new Error(`server did not become ready within ${START_TIMEOUT_MS}ms`),
+				);
+			}, START_TIMEOUT_MS);
+			function onData(chunk: Buffer) {
+				stderr += chunk.toString();
+				if (stderr.includes(READY_MARKER)) {
+					cleanup();
+					resolve();
+				}
+			}
+			function onError(error: Error) {
+				cleanup();
+				reject(error);
+			}
+			function onEarlyExit() {
+				cleanup();
+				reject(new Error("server exited before becoming ready"));
+			}
+			function cleanup() {
+				clearTimeout(timer);
+				child.stderr?.off("data", onData);
+				child.off("error", onError);
+				child.off("exit", onEarlyExit);
+			}
+			child.stderr?.on("data", onData);
+			child.on("error", onError);
+			child.once("exit", onEarlyExit);
+		});
+	}
+
+	async function waitForExit(): Promise<number | null> {
+		let timedOut = false;
+		const timer = setTimeout(() => {
+			timedOut = true;
+			// Fail-and-cleanup: make sure the child cannot outlive the test.
+			child.kill("SIGKILL");
+		}, EXIT_TIMEOUT_MS);
+		try {
+			const code = await exited;
+			if (timedOut) {
+				throw new Error(
+					`server did not exit within ${EXIT_TIMEOUT_MS}ms; killed`,
+				);
+			}
+			return code;
+		} finally {
+			clearTimeout(timer);
+		}
+	}
+
+	return { child, waitForReady, waitForExit };
+}
+
+/**
+ * Assert that no server process (or descendant of one) survived the test:
+ * scan the process table for any live entry still pointing at SERVER_PATH.
+ */
+async function expectNoOrphanedServerProcesses(): Promise<void> {
+	const { stdout } = await execFileAsync("ps", ["-eo", "pid=,ppid=,args="]);
+	const leftovers = stdout
+		.split("\n")
+		.map((line) => line.trim())
+		.filter((line) => line.length > 0)
+		// Exclude this vitest worker itself (its argv contains the test path,
+		// not SERVER_PATH); match only actual spawned server command lines.
+		.filter((line) =>
+			line.split(/\s+/).slice(2).join(" ").includes(SERVER_PATH),
+		);
+	expect(
+		leftovers,
+		`orphaned server processes remain:\n${leftovers.join("\n")}`,
+	).toEqual([]);
+}
+
+describe("stdio server lifecycle", () => {
+	it(
+		"exits with code 0 when the client closes stdin without sending any signal",
+		async () => {
+			const { child, waitForReady, waitForExit } = spawnServer();
+			try {
+				await waitForReady();
+				// Simulate client disconnect: close stdin only. No signal is sent.
+				child.stdin?.end();
+				const code = await waitForExit();
+				expect(code).toBe(0);
+			} finally {
+				if (child.exitCode === null && child.signalCode === null) {
+					child.kill("SIGKILL");
+				}
+			}
+			await expectNoOrphanedServerProcesses();
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"still exits with code 0 when SIGTERM is received",
+		async () => {
+			const { child, waitForReady, waitForExit } = spawnServer();
+			try {
+				await waitForReady();
+				child.kill("SIGTERM");
+				const code = await waitForExit();
+				expect(code).toBe(0);
+			} finally {
+				if (child.exitCode === null && child.signalCode === null) {
+					child.kill("SIGKILL");
+				}
+			}
+			await expectNoOrphanedServerProcesses();
+		},
+		TEST_TIMEOUT_MS,
+	);
+
+	it(
+		"still exits with code 0 when SIGINT is received",
+		async () => {
+			const { child, waitForReady, waitForExit } = spawnServer();
+			try {
+				await waitForReady();
+				child.kill("SIGINT");
+				const code = await waitForExit();
+				expect(code).toBe(0);
+			} finally {
+				if (child.exitCode === null && child.signalCode === null) {
+					child.kill("SIGKILL");
+				}
+			}
+			await expectNoOrphanedServerProcesses();
+		},
+		TEST_TIMEOUT_MS,
+	);
+});


### PR DESCRIPTION
Fixes #25, #27, and addresses #28 along the way. #29 covers the launcher-side signal problem; it needs no code change, so it stays open as a recommendation.

## What was wrong

The stdio entrypoint only reacted to SIGINT and SIGTERM. When a client shuts down it normally just closes the pipes, so the node process survived every disconnect, got reparented to PID 1, and lingered until killed by hand. Two things kept it alive on its own: in SDK 1.17.x `StdioServerTransport` never listens for stdin `end`/`close`, so its `onclose` never fires, and module-level `EphemeralNotebookStore` cleanup intervals keep the event loop from ever draining.

## The change

`cli/stdio-server.ts` now:

- exits when stdin reaches `end` or `close`,
- hooks the server-level `onclose` callback (I checked the installed SDK's `Protocol.connect()` wiring before relying on it; transport close chains into that callback),
- routes all of those plus the two signal handlers through one idempotent shutdown guard,
- keeps the existing signal messages and exit codes exactly as they were.

`dist/cli/stdio-server.js` is rebuilt with `npm run build:stdio`. That command also regenerated `dist/src/config.js` and `dist/src/index.js`, which had drifted from src/ since the telemetry commit never rebuilt dist; those land as their own chore commit (#28).

New regression tests live in `tests/stdio-lifecycle.test.ts`. They spawn the real built entrypoint, so they need a build first.

## Verification

All run against the rebuilt `dist/cli/stdio-server.js`:

- `npx vitest run tests/stdio-lifecycle.test.ts`: 3 passed. Closing stdin with no signal exits 0 well inside a 5s bound (the same probe on unpatched HEAD stayed alive past 6 seconds), SIGTERM exits 0, SIGINT exits 0. Every case rescans the process table afterward for anything still running the server path.
- `npx vitest run` (full suite): 40 passed (37 pre-existing plus 3 new).
- `npm run typecheck`: still fails on two pre-existing errors in `src/tools/operations/index.ts` and `src/utils/validation.ts`; neither file is touched here.
- Biome is clean on the new test file. `cli/stdio-server.ts` has format complaints that unmodified HEAD also produces under biome 1.9.4 defaults; I left those alone to keep the diff narrow.

One setup note: vitest isn't pinned anywhere even though package.json declares `"test": "vitest"`, and current vitest won't start on Node 18. I ran vitest 1.6.1 installed with `--no-save --no-package-lock`; package.json and package-lock.json are unchanged in this PR.